### PR TITLE
refactor: extractor errors are now in json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,7 @@ dependencies = [
  "macros",
  "r2d2",
  "serde",
+ "serde_json",
  "utoipa",
  "utoipa-redoc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ macros = { version = "0.1.0", path = "workspace/macros" }
 r2d2 = "0.8.10"
 # Serialization, deserialization. JSON transformations
 serde = "1.0.189"
+serde_json = "1.0.107"
 # OpenApi metadata
 utoipa = { version = "4.0.0", features = ["actix_extras", "chrono", "preserve_order"] }
 # OpenApi render

--- a/src/routes/centers.rs
+++ b/src/routes/centers.rs
@@ -32,7 +32,6 @@ pub fn routes() -> Scope {
 }
 
 #[utoipa::path(
-    get,
     context_path = "/centers",
     params(PaginationParam),
     responses(
@@ -56,7 +55,6 @@ async fn all(
 }
 
 #[utoipa::path(
-    get,
     context_path = "/centers",
     responses(
         (status = 200, body = CenterWithAddress),

--- a/src/routes/centers.rs
+++ b/src/routes/centers.rs
@@ -62,7 +62,7 @@ async fn all(
     path = "/centers/{id}",
     responses(
         (status = 200, body = CenterWithAddress),
-        (status = NOT_FOUND, body = JsonError)
+        (status = 404, body = JsonError)
     ),
     params(
         ("id" = i64, Path, description = "Center id")

--- a/src/routes/centers.rs
+++ b/src/routes/centers.rs
@@ -33,12 +33,10 @@ pub fn routes() -> Scope {
 
 #[utoipa::path(
     get,
-    path = "/centers",
+    context_path = "/centers",
+    params(PaginationParam),
     responses(
         (status = 200, description = "Paginated list of centers", body = PaginatedCenters),
-    ),
-    params(
-        PaginationParam
     ),
     tag = "centers"
 )]
@@ -59,13 +57,10 @@ async fn all(
 
 #[utoipa::path(
     get,
-    path = "/centers/{id}",
+    context_path = "/centers",
     responses(
         (status = 200, body = CenterWithAddress),
         (status = 404, body = JsonError)
-    ),
-    params(
-        ("id" = i64, Path, description = "Center id")
     ),
     tag = "centers"
 )]

--- a/src/routes/mission_types.rs
+++ b/src/routes/mission_types.rs
@@ -38,12 +38,10 @@ pub fn routes() -> Scope {
 
 #[utoipa::path(
     get,
-    path = "/mission_types",
+    context_path = "/mission_types",
+    params(PaginationParam),
     responses(
         (status = 200, description = "Paginated list of missions types", body = PaginatedMissionTypes),
-    ),
-    params(
-        PaginationParam
     ),
     tag = "mission_types"
 )]
@@ -64,13 +62,10 @@ async fn all(
 
 #[utoipa::path(
     get,
-    path = "/mission_types/{id}",
+    context_path = "/mission_types",
     responses(
         (status = 200, body = MissionType),
         (status = 404, body = JsonError)
-    ),
-    params(
-        ("id" = i64, Path, description = "Missions types id")
     ),
     tag = "mission_types"
 )]
@@ -83,7 +78,7 @@ async fn get(id: web::Path<i64>, pool: web::Data<DbPool>) -> Result<impl Respond
 
 #[utoipa::path(
     post,
-    path = "/mission_types",
+    context_path = "/mission_types",
     responses(
         (status = 200, body = MissionType),
         (status = 400, body = JsonError)
@@ -107,14 +102,11 @@ async fn post(
 
 #[utoipa::path(
     put,
-    path = "/mission_types/{id}",
+    context_path = "/mission_types",
     responses(
         (status = 200, body = MissionType),
         (status = 400, body = JsonError),
         (status = 404, body = JsonError),
-    ),
-    params(
-        ("id" = i64, Path, description = "Id of the mission type to update")
     ),
     tag = "mission_types"
 )]
@@ -137,13 +129,10 @@ async fn put(
 
 #[utoipa::path(
     delete,
-    path = "/mission_types/{id}",
+    context_path = "/mission_types",
     responses(
         (status = 200, body = MissionType, description = "The deleted mission type"),
         (status = 404, body = JsonError)
-    ),
-    params(
-        ("id" = i64, Path, description = "Id of the mission type to delete")
     ),
     tag = "mission_types"
 )]

--- a/src/routes/mission_types.rs
+++ b/src/routes/mission_types.rs
@@ -37,7 +37,6 @@ pub fn routes() -> Scope {
 }
 
 #[utoipa::path(
-    get,
     context_path = "/mission_types",
     params(PaginationParam),
     responses(
@@ -61,7 +60,6 @@ async fn all(
 }
 
 #[utoipa::path(
-    get,
     context_path = "/mission_types",
     responses(
         (status = 200, body = MissionType),
@@ -77,7 +75,6 @@ async fn get(id: web::Path<i64>, pool: web::Data<DbPool>) -> Result<impl Respond
 }
 
 #[utoipa::path(
-    post,
     context_path = "/mission_types",
     responses(
         (status = 200, body = MissionType),
@@ -101,7 +98,6 @@ async fn post(
 }
 
 #[utoipa::path(
-    put,
     context_path = "/mission_types",
     responses(
         (status = 200, body = MissionType),
@@ -128,7 +124,6 @@ async fn put(
 }
 
 #[utoipa::path(
-    delete,
     context_path = "/mission_types",
     responses(
         (status = 200, body = MissionType, description = "The deleted mission type"),

--- a/src/routes/mission_types.rs
+++ b/src/routes/mission_types.rs
@@ -67,7 +67,7 @@ async fn all(
     path = "/mission_types/{id}",
     responses(
         (status = 200, body = MissionType),
-        (status = NOT_FOUND)
+        (status = 404, body = JsonError)
     ),
     params(
         ("id" = i64, Path, description = "Missions types id")
@@ -86,7 +86,7 @@ async fn get(id: web::Path<i64>, pool: web::Data<DbPool>) -> Result<impl Respond
     path = "/mission_types",
     responses(
         (status = 200, body = MissionType),
-        (status = 400)
+        (status = 400, body = JsonError)
     ),
     tag = "mission_types"
 )]
@@ -110,7 +110,8 @@ async fn post(
     path = "/mission_types/{id}",
     responses(
         (status = 200, body = MissionType),
-        (status = 400)
+        (status = 400, body = JsonError),
+        (status = 404, body = JsonError),
     ),
     params(
         ("id" = i64, Path, description = "Id of the mission type to update")
@@ -139,7 +140,7 @@ async fn put(
     path = "/mission_types/{id}",
     responses(
         (status = 200, body = MissionType, description = "The deleted mission type"),
-        (status = 400)
+        (status = 404, body = JsonError)
     ),
     params(
         ("id" = i64, Path, description = "Id of the mission type to delete")

--- a/src/routes/nurses.rs
+++ b/src/routes/nurses.rs
@@ -39,7 +39,6 @@ pub fn routes() -> Scope {
 }
 
 #[utoipa::path(
-    get,
     context_path = "/nurses",
     params(PaginationParam),
     responses(
@@ -63,7 +62,6 @@ async fn all(
 }
 
 #[utoipa::path(
-    get,
     context_path = "/nurses",
     responses(
         (status = 200, body = Nurse),
@@ -79,7 +77,6 @@ async fn get(id: web::Path<i64>, pool: web::Data<DbPool>) -> Result<impl Respond
 }
 
 #[utoipa::path(
-    post,
     path = "/nurses",
     responses(
         (status = 200, body = NurseRecord),
@@ -100,7 +97,6 @@ async fn post(new_record: web::Json<NewNurse>, pool: web::Data<DbPool>) -> Resul
 }
 
 #[utoipa::path(
-    put,
     context_path = "/nurses",
     responses(
         (status = 200, body = NurseRecord),
@@ -127,7 +123,6 @@ async fn put(
 }
 
 #[utoipa::path(
-    delete,
     context_path = "/nurses",
     responses(
         (status = 200, body = NurseRecord, description = "The deleted nurse"),

--- a/src/routes/nurses.rs
+++ b/src/routes/nurses.rs
@@ -40,12 +40,10 @@ pub fn routes() -> Scope {
 
 #[utoipa::path(
     get,
-    path = "/nurses",
+    context_path = "/nurses",
+    params(PaginationParam),
     responses(
         (status = 200, description = "Paginated list of nurses", body = PaginatedNurses),
-    ),
-    params(
-        PaginationParam
     ),
     tag = "nurses"
 )]
@@ -66,13 +64,10 @@ async fn all(
 
 #[utoipa::path(
     get,
-    path = "/nurses/{id}",
+    context_path = "/nurses",
     responses(
         (status = 200, body = Nurse),
         (status = 404, body = JsonError)
-    ),
-    params(
-        ("id" = i64, Path, description = "Nurse id")
     ),
     tag = "nurses"
 )]
@@ -106,14 +101,11 @@ async fn post(new_record: web::Json<NewNurse>, pool: web::Data<DbPool>) -> Resul
 
 #[utoipa::path(
     put,
-    path = "/nurses/{id}",
+    context_path = "/nurses",
     responses(
         (status = 200, body = NurseRecord),
         (status = 400, body = JsonError),
         (status = 404, body = JsonError),
-    ),
-    params(
-        ("id" = i64, Path, description = "Id of the nurse to update")
     ),
     tag = "nurses"
 )]
@@ -136,13 +128,10 @@ async fn put(
 
 #[utoipa::path(
     delete,
-    path = "/nurses/{id}",
+    context_path = "/nurses",
     responses(
         (status = 200, body = NurseRecord, description = "The deleted nurse"),
         (status = 404, body = JsonError),
-    ),
-    params(
-        ("id" = i64, Path, description = "Id of the nurse to delete")
     ),
     tag = "nurses"
 )]

--- a/src/routes/nurses.rs
+++ b/src/routes/nurses.rs
@@ -69,7 +69,7 @@ async fn all(
     path = "/nurses/{id}",
     responses(
         (status = 200, body = Nurse),
-        (status = NOT_FOUND, body = JsonError)
+        (status = 404, body = JsonError)
     ),
     params(
         ("id" = i64, Path, description = "Nurse id")
@@ -88,7 +88,7 @@ async fn get(id: web::Path<i64>, pool: web::Data<DbPool>) -> Result<impl Respond
     path = "/nurses",
     responses(
         (status = 200, body = NurseRecord),
-        (status = 400)
+        (status = 400, body = JsonError),
     ),
     tag = "nurses"
 )]
@@ -109,7 +109,8 @@ async fn post(new_record: web::Json<NewNurse>, pool: web::Data<DbPool>) -> Resul
     path = "/nurses/{id}",
     responses(
         (status = 200, body = NurseRecord),
-        (status = 400)
+        (status = 400, body = JsonError),
+        (status = 404, body = JsonError),
     ),
     params(
         ("id" = i64, Path, description = "Id of the nurse to update")
@@ -138,7 +139,7 @@ async fn put(
     path = "/nurses/{id}",
     responses(
         (status = 200, body = NurseRecord, description = "The deleted nurse"),
-        (status = 400)
+        (status = 404, body = JsonError),
     ),
     params(
         ("id" = i64, Path, description = "Id of the nurse to delete")

--- a/src/routes/patients.rs
+++ b/src/routes/patients.rs
@@ -70,7 +70,7 @@ async fn all(
     path = "/patients/{id}",
     responses(
         (status = 200, body = Patient),
-        (status = NOT_FOUND, body = JsonError)
+        (status = 404, body = JsonError)
     ),
     params(
         ("id" = i64, Path, description = "Patient id")
@@ -89,7 +89,7 @@ async fn get(id: web::Path<i64>, pool: web::Data<DbPool>) -> Result<impl Respond
     path = "/patients",
     responses(
         (status = 200, body = PatientRecord),
-        (status = 400)
+        (status = 400, body = JsonError),
     ),
     tag = "patients"
 )]
@@ -110,7 +110,8 @@ async fn post(new_record: Json<NewPatient>, pool: web::Data<DbPool>) -> Result<i
     path = "/patients/{id}",
     responses(
         (status = 200, body = PatientRecord),
-        (status = 400)
+        (status = 400, body = JsonError),
+        (status = 404, body = JsonError),
     ),
     params(
         ("id" = i64, Path, description = "Id of the patient to update")
@@ -139,7 +140,7 @@ async fn put(
     path = "/patients/{id}",
     responses(
         (status = 200, body = PatientRecord, description = "The deleted patient"),
-        (status = 400)
+        (status = 404, body = JsonError),
     ),
     params(
         ("id" = i64, Path, description = "Id of the patient to delete")

--- a/src/routes/patients.rs
+++ b/src/routes/patients.rs
@@ -40,7 +40,6 @@ pub fn routes() -> Scope {
 }
 
 #[utoipa::path(
-    get,
     context_path = "/patients",
     params(PaginationParam),
     responses(
@@ -64,7 +63,6 @@ async fn all(
 }
 
 #[utoipa::path(
-    get,
     context_path = "/patients",
     responses(
         (status = 200, body = Patient),
@@ -80,7 +78,6 @@ async fn get(id: web::Path<i64>, pool: web::Data<DbPool>) -> Result<impl Respond
 }
 
 #[utoipa::path(
-    post,
     path = "/patients",
     responses(
         (status = 200, body = PatientRecord),
@@ -101,7 +98,6 @@ async fn post(new_record: Json<NewPatient>, pool: web::Data<DbPool>) -> Result<i
 }
 
 #[utoipa::path(
-    put,
     context_path = "/patients",
     responses(
         (status = 200, body = PatientRecord),
@@ -128,7 +124,6 @@ async fn put(
 }
 
 #[utoipa::path(
-    delete,
     context_path = "/patients",
     responses(
         (status = 200, body = PatientRecord, description = "The deleted patient"),

--- a/src/routes/patients.rs
+++ b/src/routes/patients.rs
@@ -41,12 +41,10 @@ pub fn routes() -> Scope {
 
 #[utoipa::path(
     get,
-    path = "/patients",
+    context_path = "/patients",
+    params(PaginationParam),
     responses(
         (status = 200, description = "Paginated list of patients", body = PaginatedPatients),
-    ),
-    params(
-        PaginationParam
     ),
     tag = "patients"
 )]
@@ -67,13 +65,10 @@ async fn all(
 
 #[utoipa::path(
     get,
-    path = "/patients/{id}",
+    context_path = "/patients",
     responses(
         (status = 200, body = Patient),
         (status = 404, body = JsonError)
-    ),
-    params(
-        ("id" = i64, Path, description = "Patient id")
     ),
     tag = "patients"
 )]
@@ -107,14 +102,11 @@ async fn post(new_record: Json<NewPatient>, pool: web::Data<DbPool>) -> Result<i
 
 #[utoipa::path(
     put,
-    path = "/patients/{id}",
+    context_path = "/patients",
     responses(
         (status = 200, body = PatientRecord),
         (status = 400, body = JsonError),
         (status = 404, body = JsonError),
-    ),
-    params(
-        ("id" = i64, Path, description = "Id of the patient to update")
     ),
     tag = "patients"
 )]
@@ -137,13 +129,10 @@ async fn put(
 
 #[utoipa::path(
     delete,
-    path = "/patients/{id}",
+    context_path = "/patients",
     responses(
         (status = 200, body = PatientRecord, description = "The deleted patient"),
         (status = 404, body = JsonError),
-    ),
-    params(
-        ("id" = i64, Path, description = "Id of the patient to delete")
     ),
     tag = "patients"
 )]

--- a/src/routes/skills.rs
+++ b/src/routes/skills.rs
@@ -38,12 +38,10 @@ pub fn routes() -> Scope {
 
 #[utoipa::path(
     get,
-    path = "/skills",
+    context_path = "/skills",
+    params(PaginationParam),
     responses(
         (status = 200, description = "Paginated list of skills", body = PaginatedSkills),
-    ),
-    params(
-        PaginationParam
     ),
     tag = "skills"
 )]
@@ -64,13 +62,10 @@ async fn all(
 
 #[utoipa::path(
     get,
-    path = "/skills/{id}",
+    context_path = "/skills",
     responses(
         (status = 200, body = Skill),
         (status = 404, body = JsonError),
-    ),
-    params(
-        ("id" = i64, Path, description = "Skill id")
     ),
     tag = "skills"
 )]
@@ -83,7 +78,7 @@ async fn get(id: web::Path<i64>, pool: web::Data<DbPool>) -> Result<impl Respond
 
 #[utoipa::path(
     post,
-    path = "/skills",
+    context_path = "/skills",
     responses(
         (status = 200, body = Skill),
         (status = 400, body = JsonError),
@@ -104,14 +99,11 @@ async fn post(new_skill: web::Json<NewSkill>, pool: web::Data<DbPool>) -> Result
 
 #[utoipa::path(
     put,
-    path = "/skills/{id}",
+    context_path = "/skills",
     responses(
         (status = 200, body = Skill),
         (status = 400, body = JsonError),
         (status = 404, body = JsonError),
-    ),
-    params(
-        ("id" = i64, Path, description = "Id of the skill to update")
     ),
     tag = "skills"
 )]
@@ -134,13 +126,10 @@ async fn put(
 
 #[utoipa::path(
     delete,
-    path = "/skills/{id}",
+    context_path = "/skills",
     responses(
         (status = 200, body = Skill, description = "The deleted skill"),
         (status = 404, body = JsonError),
-    ),
-    params(
-        ("id" = i64, Path, description = "Id of the skill to delete")
     ),
     tag = "skills"
 )]

--- a/src/routes/skills.rs
+++ b/src/routes/skills.rs
@@ -67,7 +67,7 @@ async fn all(
     path = "/skills/{id}",
     responses(
         (status = 200, body = Skill),
-        (status = NOT_FOUND)
+        (status = 404, body = JsonError),
     ),
     params(
         ("id" = i64, Path, description = "Skill id")
@@ -86,7 +86,7 @@ async fn get(id: web::Path<i64>, pool: web::Data<DbPool>) -> Result<impl Respond
     path = "/skills",
     responses(
         (status = 200, body = Skill),
-        (status = 400)
+        (status = 400, body = JsonError),
     ),
     tag = "skills"
 )]
@@ -107,7 +107,8 @@ async fn post(new_skill: web::Json<NewSkill>, pool: web::Data<DbPool>) -> Result
     path = "/skills/{id}",
     responses(
         (status = 200, body = Skill),
-        (status = 400)
+        (status = 400, body = JsonError),
+        (status = 404, body = JsonError),
     ),
     params(
         ("id" = i64, Path, description = "Id of the skill to update")
@@ -136,7 +137,7 @@ async fn put(
     path = "/skills/{id}",
     responses(
         (status = 200, body = Skill, description = "The deleted skill"),
-        (status = 400)
+        (status = 404, body = JsonError),
     ),
     params(
         ("id" = i64, Path, description = "Id of the skill to delete")

--- a/src/routes/skills.rs
+++ b/src/routes/skills.rs
@@ -37,7 +37,6 @@ pub fn routes() -> Scope {
 }
 
 #[utoipa::path(
-    get,
     context_path = "/skills",
     params(PaginationParam),
     responses(
@@ -61,7 +60,6 @@ async fn all(
 }
 
 #[utoipa::path(
-    get,
     context_path = "/skills",
     responses(
         (status = 200, body = Skill),
@@ -77,7 +75,6 @@ async fn get(id: web::Path<i64>, pool: web::Data<DbPool>) -> Result<impl Respond
 }
 
 #[utoipa::path(
-    post,
     context_path = "/skills",
     responses(
         (status = 200, body = Skill),
@@ -98,7 +95,6 @@ async fn post(new_skill: web::Json<NewSkill>, pool: web::Data<DbPool>) -> Result
 }
 
 #[utoipa::path(
-    put,
     context_path = "/skills",
     responses(
         (status = 200, body = Skill),
@@ -125,7 +121,6 @@ async fn put(
 }
 
 #[utoipa::path(
-    delete,
     context_path = "/skills",
     responses(
         (status = 200, body = Skill, description = "The deleted skill"),


### PR DESCRIPTION
I configured the [`Json`](https://docs.rs/actix-web/latest/actix_web/web/struct.Json.html) and [`Query`](https://docs.rs/actix-web/latest/actix_web/web/struct.Query.html) extractors to return errors as json.

I also updated to doc to mention that errors are returned a `JsonError`.