### PR TITLE
feat: iCalendar export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "env_logger",
+ "icalendar",
  "macros",
  "r2d2",
  "serde",
@@ -384,8 +385,10 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets",
 ]
 
@@ -629,8 +632,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -729,6 +734,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "icalendar"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "753f71e82c28fb469f0d813019eea1caaf4e8064b1e3822556f5b6278c2869a4"
+dependencies = [
+ "chrono",
+ "iso8601",
+ "uuid",
+]
+
+[[package]]
 name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +784,15 @@ dependencies = [
  "hermit-abi",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "iso8601"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -883,6 +908,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,6 +932,16 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1507,6 +1548,16 @@ dependencies = [
  "serde",
  "serde_json",
  "utoipa",
+]
+
+[[package]]
+name = "uuid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
+dependencies = [
+ "getrandom",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ diesel = { version = "2.1.3", default-features = false, features = ["postgres", 
 diesel_migrations = { version = "2.1.0", features = ["postgres"] }
 # Logging facility
 env_logger = "0.10.0"
+icalendar = { version = "0.15.7", default-features = false }
 # Macros definition for easier common manipulations
 macros = { version = "0.1.0", path = "workspace/macros" }
 # Database pool

--- a/src/models/addresses.rs
+++ b/src/models/addresses.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use diesel::{Identifiable, Queryable, Selectable};
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -15,4 +17,20 @@ pub struct Address {
     city_name: String,
     /// Address complement
     complement: Option<String>,
+}
+
+impl Display for Address {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}{} {}, {} {}",
+            self.complement
+                .as_ref()
+                .map_or(String::new(), |c| format!("{}, ", c)),
+            self.number.map_or(String::new(), |n| n.to_string()),
+            self.street_name,
+            self.postcode,
+            self.city_name,
+        )
+    }
 }

--- a/src/models/mission_types.rs
+++ b/src/models/mission_types.rs
@@ -1,14 +1,14 @@
-use diesel::{AsChangeset, Insertable, Queryable};
+use diesel::{AsChangeset, Insertable, Queryable, Selectable};
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
 use crate::schema::mission_types;
 
-#[derive(Serialize, Queryable, ToSchema)]
+#[derive(Serialize, Queryable, Selectable, ToSchema)]
 #[diesel(table_name = mission_types)]
 pub struct MissionType {
     id: i64,
-    name: String,
+    pub name: String,
     people_required: i16,
 }
 

--- a/src/models/missions.rs
+++ b/src/models/missions.rs
@@ -1,17 +1,17 @@
 use chrono::NaiveDateTime;
-use diesel::{AsChangeset, Insertable, Queryable};
+use diesel::{AsChangeset, Insertable, Queryable, Selectable};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use super::{MissionType, Patient};
 use crate::schema::missions;
 
-#[derive(Serialize, Queryable, ToSchema)]
+#[derive(Serialize, Queryable, Selectable, ToSchema)]
 #[diesel(table_name = missions)]
 pub struct MissionRecord {
     id: i64,
     /// Mission description
-    desc: Option<String>,
+    pub desc: Option<String>,
     /// Start of the time window the mission should be fulfilled in
     start: NaiveDateTime,
     /// End of the time window the mission should be fulfilled in
@@ -28,12 +28,15 @@ pub struct MissionRecord {
     id_patient: i64,
 }
 
-#[derive(Serialize, Queryable, ToSchema)]
+#[derive(Serialize, Queryable, Selectable, ToSchema)]
 pub struct Mission {
     #[serde(flatten)]
-    mission: MissionRecord,
-    mission_type: MissionType,
-    patient: Patient,
+    #[diesel(embed)]
+    pub mission: MissionRecord,
+    #[diesel(embed)]
+    pub mission_type: MissionType,
+    #[diesel(embed)]
+    pub patient: Patient,
 }
 
 #[derive(Deserialize, AsChangeset, ToSchema)]

--- a/src/models/nurses.rs
+++ b/src/models/nurses.rs
@@ -22,7 +22,7 @@ pub struct Nurse {
     #[serde(flatten)]
     pub nurse: NurseRecord,
     #[serde(flatten)]
-    user: User,
+    pub user: User,
     address: Address,
 }
 

--- a/src/models/patients.rs
+++ b/src/models/patients.rs
@@ -1,11 +1,11 @@
-use diesel::{AsChangeset, Insertable, Queryable};
+use diesel::{AsChangeset, Insertable, Queryable, Selectable};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use super::{Address, User};
 use crate::schema::patients;
 
-#[derive(Serialize, Queryable, ToSchema)]
+#[derive(Serialize, Queryable, Selectable, ToSchema)]
 #[diesel(table_name = patients)]
 pub struct PatientRecord {
     id: i64,
@@ -13,14 +13,17 @@ pub struct PatientRecord {
     id_address: i64,
 }
 
-#[derive(Serialize, Queryable, ToSchema)]
+#[derive(Serialize, Queryable, Selectable, ToSchema)]
 #[diesel(table_name = patients)]
 pub struct Patient {
     #[serde(flatten)]
+    #[diesel(embed)]
     patient: PatientRecord,
     #[serde(flatten)]
-    user: User,
-    address: Address,
+    #[diesel(embed)]
+    pub user: User,
+    #[diesel(embed)]
+    pub address: Address,
 }
 
 #[derive(Deserialize, AsChangeset, ToSchema)]

--- a/src/models/users.rs
+++ b/src/models/users.rs
@@ -10,8 +10,8 @@ use crate::schema::users;
 #[diesel(belongs_to(Center, foreign_key = id_center))]
 pub struct User {
     id: i64,
-    fname: String,
-    lname: String,
+    pub fname: String,
+    pub lname: String,
     mail: String,
     phone: Option<String>,
     #[serde(skip)]

--- a/src/models/visits.rs
+++ b/src/models/visits.rs
@@ -1,12 +1,12 @@
 use chrono::NaiveDateTime;
-use diesel::{AsChangeset, Insertable, Queryable};
+use diesel::{AsChangeset, Insertable, Queryable, Selectable};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use super::Mission;
 use crate::schema::visits;
 
-#[derive(Serialize, Queryable, ToSchema)]
+#[derive(Serialize, Queryable, Selectable, ToSchema)]
 #[diesel(table_name = visits)]
 pub struct VisitRecord {
     id: i64,
@@ -18,11 +18,33 @@ pub struct VisitRecord {
     id_mission: i64,
 }
 
-#[derive(Serialize, Queryable, ToSchema)]
+#[derive(Serialize, Queryable, Selectable, ToSchema)]
 pub struct Visit {
     #[serde(flatten)]
+    #[diesel(embed)]
     visit: VisitRecord,
-    mission: Mission,
+    #[diesel(embed)]
+    pub mission: Mission,
+}
+
+impl From<Visit> for icalendar::Event {
+    fn from(value: Visit) -> Self {
+        use icalendar::{Component, EventLike};
+
+        icalendar::Event::new()
+            .uid(&value.visit.id.to_string())
+            .summary(&value.mission.mission_type.name)
+            .description(&format!(
+                "Patient: {} {}\n\nDescription: {}\n\n",
+                value.mission.patient.user.fname,
+                value.mission.patient.user.lname.to_uppercase(),
+                value.mission.mission.desc.unwrap_or_default()
+            ))
+            .starts(value.visit.start)
+            .ends(value.visit.end)
+            .location(&value.mission.patient.address.to_string())
+            .done()
+    }
 }
 
 #[derive(Deserialize, AsChangeset, ToSchema)]

--- a/src/routes/nurses.rs
+++ b/src/routes/nurses.rs
@@ -200,13 +200,15 @@ async fn ical(id: web::Path<i64>, pool: web::Data<DbPool>) -> Result<impl Respon
         .select(Visit::as_select())
         .load_iter::<Visit, DefaultLoadingMode>(&mut pool.get()?)?;
 
-    let mut cal: Calendar = visits.map(|visit| Event::from(visit.unwrap())).collect();
+    let cal: Result<Calendar> = visits.map(|visit| Ok(Event::from(visit?))).collect();
 
-    cal.name(&format!(
-        "Planning de {} {}",
-        nurse.fname,
-        nurse.lname.to_uppercase()
-    ));
+    cal.map(|mut c| {
+        c.name(&format!(
+            "Planning de {} {}",
+            nurse.fname,
+            nurse.lname.to_uppercase()
+        ));
 
-    Ok(cal.to_string())
+        c.to_string()
+    })
 }

--- a/src/routes/nurses.rs
+++ b/src/routes/nurses.rs
@@ -3,7 +3,10 @@ use actix_web::{
     web::{self, Json},
     Responder, Scope,
 };
-use diesel::{insert_into, BelongingToDsl, ExpressionMethods, GroupedBy, QueryDsl, RunQueryDsl};
+use diesel::{
+    connection::DefaultLoadingMode, insert_into, BelongingToDsl, ExpressionMethods, GroupedBy,
+    QueryDsl, RunQueryDsl, SelectableHelper,
+};
 use macros::{list, total};
 
 use crate::{
@@ -11,12 +14,15 @@ use crate::{
     error::{JsonError, Result},
     models::*,
     pagination::{PaginatedResponse, PaginationParam},
-    schema::{addresses, nurses, skills, users},
+    schema::{
+        addresses, l_visits_nurses, mission_types, missions, nurses, patients, skills, users,
+        visits,
+    },
 };
 
 #[derive(utoipa::OpenApi)]
 #[openapi(
-    paths(all, get, post, put, delete),
+    paths(all, get, post, put, delete, ical),
     components(schemas(
         Nurse,
         SkilledNurse,
@@ -37,6 +43,7 @@ pub fn routes() -> Scope {
         .service(post)
         .service(put)
         .service(delete)
+        .service(ical)
 }
 
 #[utoipa::path(
@@ -160,4 +167,46 @@ async fn delete(id: web::Path<i64>, pool: web::Data<DbPool>) -> Result<impl Resp
     macros::delete!(nurses, pool, *id);
 
     Ok(Json(()))
+}
+
+#[utoipa::path(
+    context_path = "/nurses",
+    responses(
+        (status = 200, body = String, description = "Icalendar data"),
+        (status = 404, body = JsonError)
+    ),
+    tag = "nurses"
+)]
+#[get("/{id}/ical")]
+async fn ical(id: web::Path<i64>, pool: web::Data<DbPool>) -> Result<impl Responder> {
+    use icalendar::*;
+
+    let nurse: User = users::table
+        .inner_join(nurses::table)
+        .filter(nurses::id.eq(*id))
+        .select(users::all_columns)
+        .first(&mut pool.get()?)?;
+
+    let visits = visits::table
+        .inner_join(
+            missions::table.inner_join(mission_types::table).inner_join(
+                patients::table
+                    .inner_join(users::table)
+                    .inner_join(addresses::table),
+            ),
+        )
+        .inner_join(l_visits_nurses::table)
+        .filter(l_visits_nurses::id_nurse.eq(*id))
+        .select(Visit::as_select())
+        .load_iter::<Visit, DefaultLoadingMode>(&mut pool.get()?)?;
+
+    let mut cal: Calendar = visits.map(|visit| Event::from(visit.unwrap())).collect();
+
+    cal.name(&format!(
+        "Planning de {} {}",
+        nurse.fname,
+        nurse.lname.to_uppercase()
+    ));
+
+    Ok(cal.to_string())
 }


### PR DESCRIPTION
# Description

I added a route to generate iCalendar data **per nurse**. I don't think we'll need an export with more than one nurse.

I tried to add as many useful info as possible in an event, please tell me if you think something else is important.

I also added a method to format an address, this could be useful somewhere else.

# Usage

You can simply query the route `/api/nurses/1/ical` where `1` is the nurse's id.

# Future work

We'll need to add a time limit to what is exported at some point, not further than 1 month ago for example.

# References

General information, some examples: https://fr.wikipedia.org/wiki/ICalendar

Used lib: https://docs.rs/icalendar/0.15.7/icalendar/index.html

iCalendar spec is defined by two RFCs: rfc5545 and rfc7986.  
iCalendar references:
- https://datatracker.ietf.org/doc/html/rfc5545
- https://icalendar.org/Home.html