### PR TITLE
feat: search query

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod documentation;
 mod error;
 mod models;
 mod pagination;
+mod params;
 mod routes;
 mod schema;
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,0 +1,3 @@
+mod search;
+
+pub use search::*;

--- a/src/params/search.rs
+++ b/src/params/search.rs
@@ -1,0 +1,27 @@
+use serde::Deserialize;
+use utoipa::IntoParams;
+
+/// Represents the parameters that could be given to search for something.
+#[derive(Default, Clone, Deserialize, IntoParams)]
+#[serde(default)]
+pub struct SearchParam {
+    /// The string to search for in the database.
+    ///
+    /// Searches are case **insensitive** and look for **substring**.
+    search: String,
+}
+
+impl SearchParam {
+    /// Returns the value wrapped with `%` to be used in database query.
+    #[must_use]
+    pub fn value(&self) -> String {
+        format!("%{}%", self.search)
+    }
+
+    /// Returns the value as it was received.
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn raw_value(&self) -> &String {
+        &self.search
+    }
+}

--- a/src/routes/mission_types.rs
+++ b/src/routes/mission_types.rs
@@ -4,8 +4,7 @@ use actix_web::{
     Responder, Scope,
 };
 use actix_web_grants::proc_macro::has_roles;
-use diesel::{insert_into, ExpressionMethods, QueryDsl, RunQueryDsl};
-use macros::{list, total};
+use diesel::{insert_into, ExpressionMethods, PgTextExpressionMethods, QueryDsl, RunQueryDsl};
 
 use crate::{
     auth::{Auth, Role},
@@ -13,6 +12,7 @@ use crate::{
     error::{JsonError, Result},
     models::{MissionType, NewMissionType, UpdateMissionType},
     pagination::{PaginatedResponse, PaginationParam},
+    params::SearchParam,
     schema::mission_types,
 };
 
@@ -43,7 +43,7 @@ pub fn routes() -> Scope {
 
 #[utoipa::path(
     context_path = "/mission_types",
-    params(PaginationParam),
+    params(PaginationParam, SearchParam),
     responses(
         (status = 200, description = "Paginated list of missions types", body = PaginatedMissionTypes),
     ),
@@ -52,18 +52,22 @@ pub fn routes() -> Scope {
 #[get("")]
 #[has_roles("Role::Manager", type = "Role")]
 async fn all(
-    query: web::Query<PaginationParam>,
+    pagination: web::Query<PaginationParam>,
+    search: web::Query<SearchParam>,
     pool: web::Data<DbPool>,
     _: Auth,
 ) -> Result<impl Responder> {
-    let q2 = query.clone();
-    let p2 = pool.clone();
+    let req = mission_types::table.filter(mission_types::name.ilike(search.value()));
 
-    let res: Vec<MissionType> = list!(mission_types, pool, query);
+    let res: Vec<MissionType> = req
+        .clone()
+        .offset(pagination.offset().into())
+        .limit(pagination.limit().into())
+        .load(&mut pool.get()?)?;
 
-    let total = total!(mission_types, p2);
+    let total = req.count().get_result::<i64>(&mut pool.get()?)? as u32;
 
-    Ok(Json(PaginatedResponse::new(res, &q2).total(total)))
+    Ok(Json(PaginatedResponse::new(res, &pagination).total(total)))
 }
 
 #[utoipa::path(

--- a/src/routes/missions.rs
+++ b/src/routes/missions.rs
@@ -4,8 +4,7 @@ use actix_web::{
     Responder, Scope,
 };
 use actix_web_grants::proc_macro::has_roles;
-use diesel::{insert_into, ExpressionMethods, QueryDsl, RunQueryDsl};
-use macros::total;
+use diesel::{insert_into, ExpressionMethods, PgTextExpressionMethods, QueryDsl, RunQueryDsl};
 
 use crate::{
     auth::{Auth, Role},
@@ -13,6 +12,7 @@ use crate::{
     error::{JsonError, Result},
     models::*,
     pagination::{PaginatedResponse, PaginationParam},
+    params::SearchParam,
     schema::{addresses, mission_types, missions, patients, users},
 };
 
@@ -44,7 +44,7 @@ pub fn routes() -> Scope {
 
 #[utoipa::path(
     context_path = "/missions",
-    params(PaginationParam),
+    params(PaginationParam, SearchParam),
     responses(
         (status = 200, description = "Paginated list of missions", body = PaginatedMissions),
     ),
@@ -53,30 +53,32 @@ pub fn routes() -> Scope {
 #[get("")]
 #[has_roles("Role::Manager", type = "Role")]
 async fn all(
-    query: web::Query<PaginationParam>,
+    pagination: web::Query<PaginationParam>,
+    search: web::Query<SearchParam>,
     pool: web::Data<DbPool>,
     _: Auth,
 ) -> Result<impl Responder> {
-    let q2 = query.clone();
-    let p2 = pool.clone();
+    let res: Vec<Mission> = missions::table
+        .inner_join(mission_types::table)
+        .inner_join(
+            patients::table
+                .inner_join(users::table)
+                .inner_join(addresses::table),
+        )
+        .filter(missions::desc.ilike(search.value()))
+        .or_filter(mission_types::name.ilike(search.value()))
+        .offset(pagination.offset().into())
+        .limit(pagination.limit().into())
+        .load(&mut pool.get()?)?;
 
-    let res: Vec<Mission> = actix_web::web::block(move || {
-        missions::table
-            .inner_join(mission_types::table)
-            .inner_join(
-                patients::table
-                    .inner_join(users::table)
-                    .inner_join(addresses::table),
-            )
-            .offset(query.offset().into())
-            .limit(query.limit().into())
-            .load(&mut pool.get().unwrap())
-    })
-    .await??;
+    let total = missions::table
+        .inner_join(mission_types::table)
+        .filter(missions::desc.ilike(search.value()))
+        .or_filter(mission_types::name.ilike(search.value()))
+        .count()
+        .get_result::<i64>(&mut pool.get()?)? as u32;
 
-    let total = total!(missions, p2);
-
-    Ok(Json(PaginatedResponse::new(res, &q2).total(total)))
+    Ok(Json(PaginatedResponse::new(res, &pagination).total(total)))
 }
 
 #[utoipa::path(

--- a/src/routes/patients.rs
+++ b/src/routes/patients.rs
@@ -4,8 +4,7 @@ use actix_web::{
     Responder, Scope,
 };
 use actix_web_grants::proc_macro::has_roles;
-use diesel::{insert_into, ExpressionMethods, QueryDsl, RunQueryDsl};
-use macros::{list, total};
+use diesel::{insert_into, ExpressionMethods, PgTextExpressionMethods, QueryDsl, RunQueryDsl};
 
 use crate::{
     auth::{Auth, Role},
@@ -13,6 +12,7 @@ use crate::{
     error::{JsonError, Result},
     models::*,
     pagination::{PaginatedResponse, PaginationParam},
+    params::SearchParam,
     schema::{addresses, patients, users},
 };
 
@@ -47,7 +47,7 @@ pub fn routes() -> Scope {
 
 #[utoipa::path(
     context_path = "/patients",
-    params(PaginationParam),
+    params(PaginationParam, SearchParam),
     responses(
         (status = 200, description = "Paginated list of patients", body = PaginatedPatients),
     ),
@@ -56,18 +56,30 @@ pub fn routes() -> Scope {
 #[get("")]
 #[has_roles("Role::Manager", type = "Role")]
 async fn all(
-    query: web::Query<PaginationParam>,
+    pagination: web::Query<PaginationParam>,
+    search: web::Query<SearchParam>,
     pool: web::Data<DbPool>,
     _: Auth,
 ) -> Result<impl Responder> {
-    let q2 = query.clone();
-    let p2 = pool.clone();
+    let res: Vec<Patient> = patients::table
+        .inner_join(users::table)
+        .inner_join(addresses::table)
+        .filter(users::fname.ilike(search.value()))
+        .or_filter(users::lname.ilike(search.value()))
+        .or_filter(users::mail.ilike(search.value()))
+        .offset(pagination.offset().into())
+        .limit(pagination.limit().into())
+        .load(&mut pool.get()?)?;
 
-    let res: Vec<Patient> = list!(patients, pool, query, users, addresses);
+    let total = patients::table
+        .inner_join(users::table)
+        .filter(users::fname.ilike(search.value()))
+        .or_filter(users::lname.ilike(search.value()))
+        .or_filter(users::mail.ilike(search.value()))
+        .count()
+        .get_result::<i64>(&mut pool.get()?)? as u32;
 
-    let total = total!(patients, p2);
-
-    Ok(Json(PaginatedResponse::new(res, &q2).total(total)))
+    Ok(Json(PaginatedResponse::new(res, &pagination).total(total)))
 }
 
 #[utoipa::path(


### PR DESCRIPTION
I added a search parameters for:

- mission_types
- missions
- skills
- centers
- zones
- patients
- nurses
- managers

A single string can be sent, it will be search **case insensitive** and as a **contains**. Fields on which it searches are not configurable, I use common sense to know which fields to filter.

I think this is everything that will need to be searched.