### PR TITLE
refactor: id_center and id_zone

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -26,16 +26,26 @@ pub struct Auth {
     iat: u64,
     /// User's id, may reference `nurses` or `managers` table.
     pub id: i64,
+    pub id_center: i64,
+    pub id_zone: Option<i64>,
     pub role: Role,
 }
 
 impl Auth {
-    pub fn new(id: i64, role: Role) -> Self {
+    /// Creates an auth structure from `(id, id_center, id_zone)`
+    ///
+    /// `id` may reference a nurse or a manager.
+    /// `id_zone` is `None` for a manager.
+    pub fn new(ids: (i64, i64, Option<i64>), role: Role) -> Self {
         let now = Utc::now();
+        let (id, id_center, id_zone) = ids;
+
         Self {
             exp: (now + Duration::hours(TOKEN_VALIDITY)).timestamp() as u64,
             iat: now.timestamp() as u64,
             id,
+            id_center,
+            id_zone,
             role,
         }
     }

--- a/src/models/users.rs
+++ b/src/models/users.rs
@@ -25,10 +25,12 @@ pub struct User {
 }
 
 #[derive(Serialize, ToSchema)]
-pub struct RoledUser {
+pub struct LoggedUser {
     #[serde(flatten)]
     pub user: User,
     pub role: Role,
+    pub id_center: i64,
+    pub id_zone: Option<i64>,
 }
 
 #[derive(Deserialize, ToSchema)]

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -11,14 +11,14 @@ use crate::{
     auth::{Auth, Role},
     database::{crypt, DbPool},
     error::{JsonError, Result},
-    models::{LoginUser, RoledUser, User},
-    schema::{managers, nurses, users},
+    models::{LoggedUser, LoginUser, User},
+    schema::{addresses, managers, nurses, users, zones},
 };
 
 #[derive(utoipa::OpenApi)]
 #[openapi(
     paths(login, logout),
-    components(schemas(LoginUser, Role, RoledUser, JsonError))
+    components(schemas(LoginUser, Role, LoggedUser, JsonError))
 )]
 pub struct Doc;
 
@@ -44,27 +44,35 @@ pub async fn login(pool: web::Data<DbPool>, user: Json<LoginUser>) -> Result<imp
         .filter(users::password.eq(crypt(user.password, users::password)))
         .first(&mut pool.get()?)?;
 
-    let nurse: Option<i64> = nurses::table
+    let nurse: Option<(i64, i64, i64)> = nurses::table
+        .inner_join(addresses::table.inner_join(zones::table))
         .filter(nurses::id_user.eq(user.id))
-        .select(nurses::id)
+        .select((nurses::id, zones::id_center, addresses::id_zone))
         .first(&mut pool.get()?)
         .optional()?;
 
-    let (id, role) = if let Some(id_nurse) = nurse {
-        (id_nurse, Role::Nurse)
+    let (ids, role) = if let Some((id, id_center, id_zone)) = nurse {
+        ((id, id_center, Some(id_zone)), Role::Nurse)
     } else {
-        (
-            managers::table
-                .filter(managers::id_user.eq(user.id))
-                .select(managers::id)
-                .first::<i64>(&mut pool.get()?)?,
-            Role::Manager,
-        )
+        let (id, id_center) = managers::table
+            .filter(managers::id_user.eq(user.id))
+            .select((managers::id, managers::id_center))
+            .first::<(i64, i64)>(&mut pool.get()?)?;
+
+        ((id, id_center, None), Role::Manager)
+    };
+
+    let auth = Auth::new(ids, role);
+    let logged_user = LoggedUser {
+        user,
+        role,
+        id_center: ids.1,
+        id_zone: ids.2,
     };
 
     Ok(HttpResponseBuilder::new(StatusCode::OK)
-        .cookie(Auth::new(id, role).try_into()?)
-        .json(RoledUser { user, role }))
+        .cookie(auth.try_into()?)
+        .json(logged_user))
 }
 
 #[utoipa::path(

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -29,7 +29,7 @@ pub fn routes() -> Scope {
 #[utoipa::path(
     context_path = "/auth",
     responses(
-        (status = 200, body = RoledUser),
+        (status = 200, body = LoggedUser),
         (status = 401),
     ),
     tag = "auth",


### PR DESCRIPTION
I added `id_center` and `id_zone` to the token and the `/login` route response.

This is useful for the frontend.
This is also useful for the backend to condition some requests.